### PR TITLE
Adding support for -h help argument

### DIFF
--- a/commandline/server/blink1-tiny-server.c
+++ b/commandline/server/blink1-tiny-server.c
@@ -34,6 +34,7 @@ static void usage(char *myName)
 "  %s [options] \n"
 "where options are: \n"
 "  -p <port> -- port to start server on \n"
+"  -h        -- print help message\n"
 "\n"
 "Supported URIs: \n"
 "    /blink1/on  -- turn blink1 on full white \n"
@@ -207,6 +208,14 @@ int main(int argc, char **argv)
         usage(argv[0]);
         exit(1);
     }
+
+    /* Quick hack to support -h */
+    for(int i=1; i<argc; i++) {
+        if( strcasecmp("-h", argv[i]) == 0 ) { 
+            usage(argv[0]);
+            exit(1);
+        }   
+    }   
 
     char* portstr;
 


### PR DESCRIPTION
This is a quick hack to avoid segfault when encountering a -h argument.
Better implementation would shift to using getopt(3).
